### PR TITLE
Fix formatting and update initial setup instructions in ThemeWagon guide

### DIFF
--- a/content/pcs/pc-themewagon/index.md
+++ b/content/pcs/pc-themewagon/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ThemeWagon: Implementación de Rutas y Diseño'
+title: "ThemeWagon: Implementación de Rutas y Diseño"
 date: 2024-10-04T12:13:17-05:00
 draft: false
 showPagination: false
@@ -11,7 +11,7 @@ En esta práctica, deberás replicar el diseño de la página proporcionada util
 
 1. **Configuración inicial**:
 
-   - Crea una nueva aplicación con `create-next-app`.
+   - Crea una nueva aplicación con `npm create vite@latest`.
    - Instala y configura TailwindCSS.
    - Analiza el diseño del Figma: [Click aquí](<https://www.figma.com/design/DyLm1Cod4TETL8YUE9Mt8X/Klean-Multipurpose-Landing-Page-(Community)?node-id=150-31&node-type=canvas&t=nv9PgnLZ6XxAFDbX-0>)
    - Descarga el siguiente archivo `.zip` que contienen los archivos del diseño: [Click aquí](https://drive.google.com/file/d/1PITx6mOSKpRiRs7vCMwMcF5gl7c0kRyw/view?usp=sharing)


### PR DESCRIPTION
This pull request includes minor updates to the `content/pcs/pc-themewagon/index.md` file, focusing on text formatting and updating instructions for creating a new application.

### Text Formatting:
* Updated the title's quotation marks from single to double for consistency. (`content/pcs/pc-themewagon/index.md`, [content/pcs/pc-themewagon/index.mdL2-R2](diffhunk://#diff-caef480c765f747287a61f2e78076b1b0472dfc7d75b5f248a6b5d866d0769b4L2-R2))

### Instruction Updates:
* Changed the command for creating a new application from `create-next-app` to `npm create vite@latest` to reflect a shift in the recommended tool. (`content/pcs/pc-themewagon/index.md`, [content/pcs/pc-themewagon/index.mdL14-R14](diffhunk://#diff-caef480c765f747287a61f2e78076b1b0472dfc7d75b5f248a6b5d866d0769b4L14-R14))